### PR TITLE
bugfix#编辑任务节点，主机名变更可能导致所有任务定时器被重置

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/urfave/cli v1.20.0
 	golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5 // indirect
 	golang.org/x/net v0.0.0-20190522155817-f3200d17e092
-	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20190530194941-fb225487d101 // indirect
 	google.golang.org/grpc v1.21.0

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -129,6 +129,9 @@ func (task *Task) ActiveListByHostId(hostId int16) ([]Task, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(taskIds) == 0 {
+		return nil, nil
+	}
 	list := make([]Task, 0)
 	err = Db.Where("status = ?  AND level = ?", Enabled, TaskLevelParent).
 		In("id", taskIds...).


### PR DESCRIPTION
bugfix#编辑任务节点，主机名变更可能导致所有任务定时器被重置